### PR TITLE
[add] ラズパイをCUIで起動したときのsudo表示バグ追加

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ client.on('message', msg => {
         msg.channel.send('制作・著作\n━━━━━\n　ⓃⒽⓀ');
     if (/^sudo /.test(msg.content) || /^sudo$/.test(msg.content))
         msg.channel.send('あなたはシステム管理者から通常の講習を受けたはずです。\n    これは通常、以下の3点に要約されます:\n\n        #1) 他人のプライバシーを尊重すること。\n        #2) タイプする前に考えること。\n        #3) 大いなる力には大いなる責任が伴うこと。');
+    if (/素うどん/.test(msg.content))
+        msg.channel.send('■■■■■■■■■■■■■■■■■■■■■■■■■■■\n    ■■■■■■■■■3■■■■■■■■:\n\n        #1) ■■■■■■■■■■■■■■■■■\n        #2) ■■■■■■■■■■■■■n        #3) ■■■■■■■■■■■■■■■■■■■');
 });
 
 client.login(process.env.DISCORD_TOKEN);


### PR DESCRIPTION
言語設定が日本語の状態のままCUIも起動するんだけど、どうやらCUIは日本語の表示には対応してないらしい。
私の初めてのsudo警告がこんな形で奪われるなんて……